### PR TITLE
Implement security checks for flashcard deletion and posting

### DIFF
--- a/src/main/java/com/codersfactory/flashcards/FlashcardCollection.java
+++ b/src/main/java/com/codersfactory/flashcards/FlashcardCollection.java
@@ -1,5 +1,6 @@
 package com.codersfactory.flashcards;
 
+import com.codersfactory.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,6 +20,8 @@ public class FlashcardCollection {
     private String title;
     @OneToMany(mappedBy = "flashcardCollection", cascade = CascadeType.ALL)
     private Set<Flashcard> flashcards = new HashSet<>();
+    @ManyToOne
+    private User user;
 
     public void addCard(Flashcard flashcard) {
         flashcards.add(flashcard);

--- a/src/main/java/com/codersfactory/flashcards/FlashcardCollectionsService.java
+++ b/src/main/java/com/codersfactory/flashcards/FlashcardCollectionsService.java
@@ -4,6 +4,10 @@ import com.codersfactory.flashcards.dto.CreateFlashcardCollectionDto;
 import com.codersfactory.flashcards.dto.CreateFlashcardDto;
 import com.codersfactory.flashcards.dto.FlashcardCollectionDto;
 import com.codersfactory.flashcards.exception.EntityNotFoundException;
+import com.codersfactory.flashcards.exception.UnauthorizedAction;
+import com.codersfactory.flashcards.exception.UnauthorizedEditException;
+import com.codersfactory.user.User;
+import com.codersfactory.user.UserService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,9 +17,11 @@ public class FlashcardCollectionsService {
 
     final FlashcardsMapper mapper = FlashcardsMapper.INSTANCE;
     final FlashcardCollectionsRepository repository;
+    final UserService userService;
 
-    FlashcardCollectionsService(FlashcardCollectionsRepository repository) {
+    FlashcardCollectionsService(FlashcardCollectionsRepository repository, UserService userService) {
         this.repository = repository;
+        this.userService = userService;
     }
 
     FlashcardCollection findById(Long id) {
@@ -23,22 +29,41 @@ public class FlashcardCollectionsService {
                 () -> new EntityNotFoundException(FlashcardCollection.class, id));
     }
 
-    FlashcardCollection mapDTO(CreateFlashcardCollectionDto dto) {
-        return mapper.collectionToEntity(dto);
+    FlashcardCollection mapDTO(CreateFlashcardCollectionDto dto, User user) {
+        return mapper.collectionToEntity(dto, user);
     }
 
     FlashcardCollectionDto toDTO(FlashcardCollection collection) {
         return mapper.collectionToDto(collection);
     }
 
-    public FlashcardCollection saveByDTO(CreateFlashcardCollectionDto dto) {
-        return repository.save(mapDTO(dto));
+    public FlashcardCollection saveByDTO(CreateFlashcardCollectionDto dto, String username) {
+        return repository.save(mapDTO(dto, userService.findByUsername(username)));
     }
 
-    public FlashcardCollectionDto addCards(Long id, List<CreateFlashcardDto> flashcards) {
+    public FlashcardCollectionDto addCards(Long id, List<CreateFlashcardDto> flashcards, String username) {
         FlashcardCollection collection = findById(id);
-        List<Flashcard> cards = flashcards.stream().map(card -> new Flashcard(card, collection)).toList();
-        cards.forEach(collection::addCard);
-        return toDTO(repository.save(collection));
+        if (checkIfUserIsOwner(collection, username)) {
+            List<Flashcard> cards = flashcards.stream().map(card -> new Flashcard(card, collection)).toList();
+            cards.forEach(collection::addCard);
+            return toDTO(repository.save(collection));
+        } else throw new UnauthorizedEditException(FlashcardCollection.class, UnauthorizedAction.POST);
+    }
+
+    public void deleteById(Long id, String username) {
+        if (checkIfUserIsOwner(findById(id), username)) repository.deleteById(id);
+        else throw new UnauthorizedEditException(FlashcardCollection.class, UnauthorizedAction.DELETE);
+    }
+
+    private boolean checkIfUserIsOwner(FlashcardCollection collection, String username) {
+        return collection.getUser().getUsername().equals(username);
+    }
+
+    public FlashcardCollectionDto saveAndGetDTO(CreateFlashcardCollectionDto dto, String name) {
+        return toDTO(saveByDTO(dto, name));
+    }
+
+    public FlashcardCollectionDto getDtoById(Long id) {
+        return toDTO(findById(id));
     }
 }

--- a/src/main/java/com/codersfactory/flashcards/FlashcardController.java
+++ b/src/main/java/com/codersfactory/flashcards/FlashcardController.java
@@ -3,9 +3,11 @@ package com.codersfactory.flashcards;
 import com.codersfactory.flashcards.dto.CreateFlashcardCollectionDto;
 import com.codersfactory.flashcards.dto.CreateFlashcardDto;
 import com.codersfactory.flashcards.dto.FlashcardCollectionDto;
+import com.codersfactory.flashcards.dto.FlashcardDto;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.CurrentSecurityContext;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,24 +21,44 @@ class FlashcardController {
     final FlashcardCollectionsService collectionsService;
 
     @GetMapping("/collection/{id}")
-    ResponseEntity<FlashcardCollection> findCollectionById(@PathVariable Long id) {
-        return new ResponseEntity<>(collectionsService.findById(id), HttpStatus.OK);
+    ResponseEntity<FlashcardCollectionDto> findCollectionById(@PathVariable Long id) {
+        return new ResponseEntity<>(collectionsService.getDtoById(id), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
-    ResponseEntity<Flashcard> getFlashcardById(@PathVariable Long id) {
-        return new ResponseEntity<>(flashcardsService.findById(id), HttpStatus.OK);
+    ResponseEntity<FlashcardDto> getFlashcardById(@PathVariable Long id) {
+        return new ResponseEntity<>(flashcardsService.getDtoById(id), HttpStatus.OK);
     }
 
     @PostMapping("/collection")
-    ResponseEntity<FlashcardCollection> createFlashcardCollection(@RequestBody CreateFlashcardCollectionDto dto) {
-        return new ResponseEntity<>(collectionsService.saveByDTO(dto), HttpStatus.OK);
+    ResponseEntity<FlashcardCollectionDto> createFlashcardCollection(@RequestBody CreateFlashcardCollectionDto dto,
+                                                                  @CurrentSecurityContext
+                                                                          (expression = "authentication?.name") String name) {
+        return new ResponseEntity<>(collectionsService.saveAndGetDTO(dto, name), HttpStatus.OK);
     }
 
     @PostMapping("/{id}")
     ResponseEntity<FlashcardCollectionDto> saveFlashcards(@PathVariable Long id,
-                                                          @RequestBody List<CreateFlashcardDto> flashcards) {
+                                                          @RequestBody List<CreateFlashcardDto> flashcards,
+                                                          @CurrentSecurityContext
+                                                                  (expression = "authentication?.name") String name) {
         return new ResponseEntity<>(collectionsService
-                .addCards(id, flashcards), HttpStatus.OK);
+                .addCards(id, flashcards, name), HttpStatus.OK);
+    }
+
+    @DeleteMapping ("/collection/{id}")
+    ResponseEntity<HttpStatus> deleteFlashcardCollectionById(@PathVariable Long id,
+                                                          @CurrentSecurityContext
+                                                                  (expression = "authentication?.name") String name) {
+        collectionsService.deleteById(id, name);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping ("/{id}")
+    ResponseEntity<HttpStatus> deleteFlashcardById(@PathVariable Long id,
+                                                             @CurrentSecurityContext
+                                                                     (expression = "authentication?.name") String name) {
+        flashcardsService.deleteById(id, name);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/codersfactory/flashcards/FlashcardsMapper.java
+++ b/src/main/java/com/codersfactory/flashcards/FlashcardsMapper.java
@@ -4,11 +4,10 @@ import com.codersfactory.flashcards.dto.CreateFlashcardCollectionDto;
 import com.codersfactory.flashcards.dto.CreateFlashcardDto;
 import com.codersfactory.flashcards.dto.FlashcardCollectionDto;
 import com.codersfactory.flashcards.dto.FlashcardDto;
+import com.codersfactory.user.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
-
-import java.util.List;
 
 @Mapper
 interface FlashcardsMapper {
@@ -23,11 +22,17 @@ interface FlashcardsMapper {
         return new FlashcardDto(card.getId(), card.getFront(), card.getBack(), card.getFlashcardCollection().getId());
     }
 
-    FlashcardCollection collectionToEntity(CreateFlashcardCollectionDto dto);
+    default FlashcardCollection collectionToEntity(CreateFlashcardCollectionDto dto, User user) {
+        FlashcardCollection flashcardCollection = new FlashcardCollection();
+        flashcardCollection.setTitle(dto.title());
+        flashcardCollection.setUser(user);
+        return flashcardCollection;
+    }
 
     default FlashcardCollectionDto collectionToDto(FlashcardCollection collection) {
         return new FlashcardCollectionDto(collection.getId(),
                 collection.getTitle(),
-                collection.getFlashcards().stream().map(this::toDto).toList());
+                collection.getFlashcards().stream().map(this::toDto).toList(),
+                collection.getUser().getId());
     }
 }

--- a/src/main/java/com/codersfactory/flashcards/FlashcardsService.java
+++ b/src/main/java/com/codersfactory/flashcards/FlashcardsService.java
@@ -3,6 +3,8 @@ package com.codersfactory.flashcards;
 import com.codersfactory.flashcards.dto.CreateFlashcardDto;
 import com.codersfactory.flashcards.dto.FlashcardDto;
 import com.codersfactory.flashcards.exception.EntityNotFoundException;
+import com.codersfactory.flashcards.exception.UnauthorizedAction;
+import com.codersfactory.flashcards.exception.UnauthorizedEditException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,11 +32,20 @@ public class FlashcardsService {
         return mapper.toDto(flashcard);
     }
 
+    FlashcardDto getDtoById(Long id) {
+        return mapEntity(findById(id));
+    }
+
     public void saveEntity(Flashcard flashcard) {
         repository.save(flashcard);
     }
 
-    public void deleteById(Long id) {
-        repository.deleteById(id);
+    public void deleteById(Long id, String username) {
+        if (checkIfUserIsOwner(id, username)) repository.deleteById(id);
+        else throw new UnauthorizedEditException(Flashcard.class, UnauthorizedAction.DELETE);
+    }
+
+    private boolean checkIfUserIsOwner(Long id, String username) {
+        return findById(id).getFlashcardCollection().getUser().getUsername().equals(username);
     }
 }

--- a/src/main/java/com/codersfactory/flashcards/dto/FlashcardCollectionDto.java
+++ b/src/main/java/com/codersfactory/flashcards/dto/FlashcardCollectionDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record FlashcardCollectionDto(
         @NotNull @Min(1) Long id,
         @NotBlank String title,
-        List<FlashcardDto> flashcards
+        List<FlashcardDto> flashcards,
+        Long ownerId
 ) {
 }

--- a/src/main/java/com/codersfactory/flashcards/exception/UnauthorizedAction.java
+++ b/src/main/java/com/codersfactory/flashcards/exception/UnauthorizedAction.java
@@ -1,0 +1,5 @@
+package com.codersfactory.flashcards.exception;
+
+public enum UnauthorizedAction {
+    GET, POST, DELETE, PUT
+}

--- a/src/main/java/com/codersfactory/flashcards/exception/UnauthorizedEditException.java
+++ b/src/main/java/com/codersfactory/flashcards/exception/UnauthorizedEditException.java
@@ -1,0 +1,7 @@
+package com.codersfactory.flashcards.exception;
+
+public class UnauthorizedEditException extends RuntimeException {
+    public UnauthorizedEditException(Class<?> entity, UnauthorizedAction action) {
+        super("User not permitted to do action: " + action + " on " + entity.getSimpleName());
+    }
+}

--- a/src/main/java/com/codersfactory/user/User.java
+++ b/src/main/java/com/codersfactory/user/User.java
@@ -1,5 +1,6 @@
 package com.codersfactory.user;
 
+import com.codersfactory.flashcards.FlashcardCollection;
 import com.codersfactory.user.dto.UserRegisterDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -7,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Entity
 @AllArgsConstructor
@@ -24,6 +27,8 @@ public class User {
     String username;
     String password;
     Roles role;
+    @OneToMany(mappedBy = "user")
+    List<FlashcardCollection> collections;
 
     public User(UserRegisterDto dto) {
         this.email = dto.email();

--- a/src/test/java/com/codersfactory/flashcards/FlashcardCollectionsServiceTest.java
+++ b/src/test/java/com/codersfactory/flashcards/FlashcardCollectionsServiceTest.java
@@ -1,7 +1,13 @@
 package com.codersfactory.flashcards;
 
 import com.codersfactory.flashcards.dto.CreateFlashcardCollectionDto;
+import com.codersfactory.flashcards.dto.CreateFlashcardDto;
 import com.codersfactory.flashcards.dto.FlashcardCollectionDto;
+import com.codersfactory.flashcards.dto.FlashcardDto;
+import com.codersfactory.flashcards.exception.UnauthorizedEditException;
+import com.codersfactory.user.Roles;
+import com.codersfactory.user.User;
+import com.codersfactory.user.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,8 +15,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class FlashcardCollectionsServiceTest {
@@ -18,8 +31,16 @@ public class FlashcardCollectionsServiceTest {
     @Mock
     FlashcardCollectionsRepository repository;
 
+    @Mock
+    UserService userService;
+
     @InjectMocks
     FlashcardCollectionsService service;
+
+    private final User mockUser = new User(1L, "email@example.com", "username",
+            "password", Roles.USER, new ArrayList<>());
+    private final FlashcardCollection collection = new FlashcardCollection(1L, "title",
+            new HashSet<>(), mockUser);
 
     @Test
     @DisplayName("Should initialize mock objects properly")
@@ -31,7 +52,7 @@ public class FlashcardCollectionsServiceTest {
     @Test
     public void mapDtoTest() {
         CreateFlashcardCollectionDto dto = new CreateFlashcardCollectionDto("title");
-        FlashcardCollection collection = service.mapDTO(dto);
+        FlashcardCollection collection = service.mapDTO(dto, mockUser);
         assertEquals(dto.title(), collection.getTitle());
     }
 
@@ -39,6 +60,7 @@ public class FlashcardCollectionsServiceTest {
     public void toDtoTest() {
         FlashcardCollection collection = new FlashcardCollection();
         collection.setTitle("title");
+        collection.setUser(mockUser);
         for (int i = 0; i < 10; i++) {
             collection.addCard(new Flashcard(Integer.toUnsignedLong(i), "front"+i, "back"+i, collection));
         }
@@ -47,5 +69,20 @@ public class FlashcardCollectionsServiceTest {
         assertNotNull(check);
         assertEquals(check.title(), collection.getTitle());
         assertEquals(10, check.flashcards().size());
+    }
+
+    @Test
+    public void addCardsByDtoTest() {
+        List<CreateFlashcardDto> cards = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            cards.add(new CreateFlashcardDto("front"+i, "back"+i, 1L));
+        }
+        when(repository.save(collection)).thenReturn(collection);
+        when(repository.findById(1L)).thenReturn(Optional.of(collection));
+        FlashcardCollectionDto dto = service.addCards(1L, cards, "username");
+
+        assertEquals(dto.flashcards().size(), 10);
+        verify(repository).save(any(FlashcardCollection.class));
+        assertThrows(UnauthorizedEditException.class, () -> service.addCards(1L, cards, "notCreator"));
     }
 }

--- a/src/test/java/com/codersfactory/flashcards/FlashcardsServiceTest.java
+++ b/src/test/java/com/codersfactory/flashcards/FlashcardsServiceTest.java
@@ -86,7 +86,7 @@ public class FlashcardsServiceTest {
 
     @Test
     public void deleteTest() {
-        service.deleteById(1L);
+        service.deleteById(1L, "username");
         verify(repository).deleteById(1L);
     }
 }

--- a/src/test/java/com/codersfactory/flashcards/FlashcardsServiceTest.java
+++ b/src/test/java/com/codersfactory/flashcards/FlashcardsServiceTest.java
@@ -2,7 +2,10 @@ package com.codersfactory.flashcards;
 
 import com.codersfactory.flashcards.dto.CreateFlashcardDto;
 import com.codersfactory.flashcards.dto.FlashcardDto;
-import org.junit.jupiter.api.BeforeEach;
+import com.codersfactory.flashcards.exception.UnauthorizedEditException;
+import com.codersfactory.user.Roles;
+import com.codersfactory.user.User;
+import org.junit.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashSet;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,15 +33,16 @@ public class FlashcardsServiceTest {
     private static final long ID_1L = 1L;
     private static final String BACK = "back";
     private static final String FRONT = "front";
-    private FlashcardCollection collection;
-    private Flashcard flashcard;
+    private final User mockUser = new User(1L, "email@e.com", "username", "password", Roles.USER, null);
+    private final FlashcardCollection collection = new FlashcardCollection(ID_1L, "title", new HashSet<>(), mockUser);
+    private final Flashcard flashcard = new Flashcard(ID_1L, FRONT, BACK, collection);;
 
-    @BeforeEach
+
+    @Before
     @DisplayName("Should create objects properly")
     public void createMockEntities() {
-        collection = new FlashcardCollection();
-        collection.setId(ID_1L);
-        flashcard = new Flashcard(ID_1L, FRONT, BACK, collection);
+        collection.setUser(mockUser);
+        collection.addCard(flashcard);
     }
     @Test
     @DisplayName("Should initialize mock objects properly")
@@ -86,7 +91,9 @@ public class FlashcardsServiceTest {
 
     @Test
     public void deleteTest() {
+        when(repository.findById(1L)).thenReturn(Optional.of(flashcard));
         service.deleteById(1L, "username");
         verify(repository).deleteById(1L);
+        assertThrows(UnauthorizedEditException.class, () -> service.deleteById(1L, "notCreator"));
     }
 }

--- a/src/test/java/com/codersfactory/user/UserServiceTest.java
+++ b/src/test/java/com/codersfactory/user/UserServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,7 +33,7 @@ public class UserServiceTest {
     final String EMAIL = "email@example.com";
     final String USERNAME = "username";
     final String PASSWORD = "password";
-    User testUser = new User(ID_1L, EMAIL, USERNAME, PASSWORD, Roles.USER);
+    User testUser = new User(ID_1L, EMAIL, USERNAME, PASSWORD, Roles.USER, new ArrayList<>());
 
     @Test
     @DisplayName("Should initialize mock objects properly")


### PR DESCRIPTION
This commit introduces essential security checks to restrict unauthorized actions related to flashcard deletion and posting functionalities. Users are now required to have the appropriate permissions before being allowed to delete or post flashcards.

Changes include:
- Added authorization logic for flashcard deletion to ensure that only the creator of a flashcard can delete it.
- Implemented access controls for flashcard posting, allowing only authenticated users with the necessary posting privileges to create new flashcards.

This security enhancement safeguards sensitive flashcard content and maintains data integrity within the application.